### PR TITLE
refactor(category page): pick up breadcrumbs from multilevel facets

### DIFF
--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -44,7 +44,7 @@ const setCategoryId = (param, self) => {
     }
     page = pathArr.join('>');
     if (window.UnbxdAnalyticsConf) {
-        window.UnbxdAnalyticsConf.page = page;
+        window.UnbxdAnalyticsConf.page = `${parent}:${page}`;
     }
     return true;
 };

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "webpack-dev-server": "^3.10.3"
     },
     "dependencies": {
-        "@unbxd-ui/unbxd-search-core": "0.2.4",
+        "@unbxd-ui/unbxd-search-core": "0.2.5",
         "prop-types": "^15.7.2"
     },
     "keywords": [

--- a/src/modules/breadcrumbs/BreadcrumbsContainer.js
+++ b/src/modules/breadcrumbs/BreadcrumbsContainer.js
@@ -19,14 +19,14 @@ class BreadcrumbsContainer extends React.PureComponent {
         const {
             getBreadCrumbsList,
             deleteCategoryFilter,
-            getSelectedBucketedFacet,
+            getBucketedFacets,
             getResults
         } = getFacetCoreMethods(unbxdCore);
 
-        const selectedMultilevelFacet = getSelectedBucketedFacet();
+        const multilevelFacets = getBucketedFacets();
         const breadCrumbsList = [];
-        Object.keys(selectedMultilevelFacet).map((selectedFacetField) => {
-            const breadcrumbs = getBreadCrumbsList(selectedFacetField);
+        multilevelFacets.map(({ filterField }) => {
+            const breadcrumbs = getBreadCrumbsList(filterField);
             breadCrumbsList.push(breadcrumbs);
         });
 

--- a/src/modules/breadcrumbs/utils/utils.js
+++ b/src/modules/breadcrumbs/utils/utils.js
@@ -1,15 +1,13 @@
 export const getFacetCoreMethods = (unbxdCore) => {
     const getBreadCrumbsList = unbxdCore.getBreadCrumbsList.bind(unbxdCore);
     const deleteCategoryFilter = unbxdCore.deleteCategoryFilter.bind(unbxdCore);
-    const getSelectedBucketedFacet = unbxdCore.getSelectedBucketedFacet.bind(
-        unbxdCore
-    );
+    const getBucketedFacets = unbxdCore.getBucketedFacets.bind(unbxdCore);
     const getResults = unbxdCore.getResults.bind(unbxdCore);
 
     return {
         getBreadCrumbsList,
         deleteCategoryFilter,
-        getSelectedBucketedFacet,
+        getBucketedFacets,
         getResults
     };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2699,10 +2699,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@unbxd-ui/unbxd-search-core@0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@unbxd-ui/unbxd-search-core/-/unbxd-search-core-0.2.4.tgz#25af5b60d5534664feb99405a896522ee8a39c2d"
-  integrity sha512-VM7/sP+CGZtN89bJuBr8A4+ngKXZyNjoeZRfWQmalYBs7nQMAxFn7WVvkLULJPJ1yvTZidU9GARRKxZu8tkn8A==
+"@unbxd-ui/unbxd-search-core@0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@unbxd-ui/unbxd-search-core/-/unbxd-search-core-0.2.5.tgz#f1e106c4f4bf334b1b775b1cd8faa1be732c7bd9"
+  integrity sha512-U5i/v+10/mLxexsC/0MaFt4XV+9+OA3ZpRf/43lfjPHG7kmNckQh9eiGOWOmclrvDbGk4sGAEuyDqn+t76ce8w==
   dependencies:
     babel-polyfill "^6.26.0"
     babel-runtime "^6.26.0"


### PR DESCRIPTION
instead of reading from selected facets, read from all multilevel facet to pick up the breadcrumb in
case of category pages.